### PR TITLE
chore: optimize burnFrom logics

### DIFF
--- a/contracts/UpgradeableERC20.sol
+++ b/contracts/UpgradeableERC20.sol
@@ -92,13 +92,14 @@ contract UpgradeableERC20 is
 
     function burnFrom(address account, uint256 amount) public virtual {
         Supply storage s = minterSupply[_msgSender()];
-        require(s.cap > 0, "UpgradeableERC20: invalid caller");
-        require(
-            s.total > amount,
-            "UpgradeableERC20: burn amount exceeds minter total supply"
-        );
-        unchecked {
-            s.total -= amount;
+        if(s.cap > 0 || s.total > 0){
+            require(
+                s.total >= amount,
+                "UpgradeableERC20: burn amount exceeds minter total supply"
+            );
+            unchecked {
+                s.total -= amount;
+            }
         }
         _spendAllowance(account, _msgSender(), amount);
         _burn(account, amount);


### PR DESCRIPTION
1. Support burnFrom if invoker is not minter so that it will be compatible with standard ERC20
2. Using `s.total >= amount` instead of `s.total > amount` for better judgement

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/conflux-evm-bridge/2)
<!-- Reviewable:end -->
